### PR TITLE
Refactor `NotInstantiable` and `InvalidConfig` class exception messages for improved clarity and consistency.

### DIFF
--- a/src/Di/Exception/NotInstantiable.php
+++ b/src/Di/Exception/NotInstantiable.php
@@ -14,7 +14,9 @@ final class NotInstantiable extends \Exception
 {
     public function __construct(string $message = '', int $code = 0, \Throwable|null $previous = null)
     {
-        $message = 'Not instantiable exception: ' . $message;
+        if ($message !== '') {
+            $message = "Not instantiable exception: \"$message\"";
+        }
 
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/InvalidConfig.php
+++ b/src/Exception/InvalidConfig.php
@@ -9,14 +9,14 @@ namespace PHPPress\Exception;
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
- *
- * @see The [guide article on handling errors](guide:runtime-handling-errors)
  */
 final class InvalidConfig extends \Exception
 {
     public function __construct(string $message = '', int $code = 0, \Throwable|null $previous = null)
     {
-        $message = 'Invalid configuration: ' . $message;
+        if ($message !== '') {
+            $message = "Invalid configuration: \"$message\"";
+        }
 
         parent::__construct($message, $code, $previous);
     }

--- a/tests/Di/ContainerTest.php
+++ b/tests/Di/ContainerTest.php
@@ -150,7 +150,7 @@ final class ContainerTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(NotInstantiable::class);
         $this->expectExceptionMessage(
-            'Not instantiable exception: Failed to instantiate component or class: "NonExistentClass".',
+            'Not instantiable exception: "Failed to instantiate component or class: "NonExistentClass"."',
         );
 
         $this->container->create(\NonExistentClass::class);
@@ -365,7 +365,7 @@ final class ContainerTest extends \PHPUnit\Framework\TestCase
 
         $this->expectException(InvalidConfig::class);
         $this->expectExceptionMessage(
-            'Invalid configuration: Dependencies indexed by name and by position in the same array are not allowed.',
+            'Invalid configuration: "Dependencies indexed by name and by position in the same array are not allowed."',
         );
 
         $this->container->get(Stub\ConstructorNullableArguments::class);
@@ -391,7 +391,7 @@ final class ContainerTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->expectException(NotInstantiable::class);
-        $this->expectExceptionMessage('Not instantiable exception: Failed to instantiate component or class: "42".');
+        $this->expectExceptionMessage('Not instantiable exception: "Failed to instantiate component or class: "42".""');
 
         $this->container->get('test');
     }
@@ -402,7 +402,7 @@ final class ContainerTest extends \PHPUnit\Framework\TestCase
 
         $this->expectException(NotInstantiable::class);
         $this->expectExceptionMessage(
-            'Not instantiable exception: Missing required parameter "car" when instantiating "' . $className . '".',
+            'Not instantiable exception: "Missing required parameter "car" when instantiating "' . $className . '"."',
         );
 
         $this->container->get($className);
@@ -496,8 +496,8 @@ final class ContainerTest extends \PHPUnit\Framework\TestCase
 
         $this->expectException(NotInstantiable::class);
         $this->expectExceptionMessage(
-            'Not instantiable exception: Missing required parameter "definitionInstance" when instantiating ' .
-            '"PHPPress\Tests\Di\Stub\Bar".',
+            'Not instantiable exception: "Missing required parameter "definitionInstance" when instantiating ' .
+            '"PHPPress\Tests\Di\Stub\Bar"."',
         );
 
         $this->container->invoke($closure);
@@ -621,7 +621,7 @@ final class ContainerTest extends \PHPUnit\Framework\TestCase
     public function testSetWithInvalidDefinition(): void
     {
         $this->expectException(InvalidConfig::class);
-        $this->expectExceptionMessage('Invalid configuration: Invalid definition for "test": invalid');
+        $this->expectExceptionMessage('Invalid configuration: "Invalid definition for "test": invalid"');
 
         $this->container->set('test', 'invalid');
     }
@@ -641,7 +641,7 @@ final class ContainerTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(InvalidConfig::class);
         $this->expectExceptionMessage(
-            'Invalid configuration: A class definition requires a "__class" or "class" member.',
+            'Invalid configuration: "A class definition requires a "__class" or "class" member."',
         );
 
         $this->container->setDefinitions(
@@ -657,7 +657,7 @@ final class ContainerTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(InvalidConfig::class);
         $this->expectExceptionMessage(
-            'Invalid configuration: A class definition requires a "__class" or "class" member.',
+            'Invalid configuration: "A class definition requires a "__class" or "class" member."',
         );
 
         $this->container->setDefinitions(
@@ -673,7 +673,7 @@ final class ContainerTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(InvalidConfig::class);
         $this->expectExceptionMessage(
-            'Invalid configuration: A class definition requires a "__class" or "class" member.',
+            'Invalid configuration: "A class definition requires a "__class" or "class" member."',
         );
 
         $this->container->setDefinitions(
@@ -702,6 +702,7 @@ final class ContainerTest extends \PHPUnit\Framework\TestCase
 
     public function testSetDefinitionsWithIntegerKeysException(): void
     {
+        $className = Stub\Car::class;
         $this->container->setDefinitions(
             [
                 Stub\EngineMarkOne::class,
@@ -711,11 +712,11 @@ final class ContainerTest extends \PHPUnit\Framework\TestCase
 
         $this->expectException(NotInstantiable::class);
         $this->expectExceptionMessage(
-            'Not instantiable exception: Missing required parameter "engine" when instantiating ' .
-            '"PHPPress\Tests\Di\Stub\Car".',
+            'Not instantiable exception: "Missing required parameter "engine" when instantiating "' .
+            $className . '"."',
         );
 
-        $this->container->get(Stub\Car::class);
+        $this->container->get($className);
     }
 
     public function testSetDefinitionsWithObjectClass(): void
@@ -731,7 +732,7 @@ final class ContainerTest extends \PHPUnit\Framework\TestCase
     public function testSetDefinitionWithScalar(): void
     {
         $this->expectException(InvalidConfig::class);
-        $this->expectExceptionMessage('Invalid configuration: Unsupported definition type for "integer".');
+        $this->expectExceptionMessage('Invalid configuration: "Unsupported definition type for "integer"."');
 
         $this->container->setDefinitions(['scalar' => 42]);
     }
@@ -778,7 +779,7 @@ final class ContainerTest extends \PHPUnit\Framework\TestCase
 
         $this->expectException(NotInstantiable::class);
         $this->expectExceptionMessage(
-            'Not instantiable exception: Missing required parameter "engine" when instantiating "' . $clasName . '".',
+            'Not instantiable exception: "Missing required parameter "engine" when instantiating "' . $clasName . '"."',
         );
 
         $this->container->get($clasName);

--- a/tests/Di/Exception/NotInstantiableTest.php
+++ b/tests/Di/Exception/NotInstantiableTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPPress\Tests\Di\Exception;
+
+use PHPPress\Di\Exception\NotInstantiable;
+use PHPUnit\Framework\Attributes\Group;
+use RuntimeException;
+
+/**
+ * Test case for the NotInstantiable class.
+ *
+ * @copyright Copyright (C) 2024 PHPPress.
+ * @license GNU General Public License version 3 or later {@see LICENSE}
+ */
+#[Group('di')]
+final class NotInstantiableTest extends \PHPUnit\Framework\TestCase
+{
+    public function testConstructor(): void
+    {
+        $exception = new NotInstantiable();
+
+        $this->assertSame('', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+
+    public function testConstructorWithFriendlyMessage(): void
+    {
+        $exception = new NotInstantiable('Test message');
+
+        $this->assertSame('Not instantiable exception: "Test message"', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+
+    public function testConstructorWithArguments(): void
+    {
+        $previousException = new RuntimeException('Previous exception');
+        $exception = new NotInstantiable('Test message', 123, $previousException);
+
+        $this->assertSame('Not instantiable exception: "Test message"', $exception->getMessage());
+        $this->assertSame(123, $exception->getCode());
+        $this->assertSame($previousException, $exception->getPrevious());
+    }
+}

--- a/tests/Di/InstanceTest.php
+++ b/tests/Di/InstanceTest.php
@@ -20,7 +20,7 @@ final class InstanceTest extends \PHPUnit\Framework\TestCase
     public function testConstructorException(): void
     {
         $this->expectException(InvalidConfig::class);
-        $this->expectExceptionMessage('Invalid configuration: The required component "id" is empty.');
+        $this->expectExceptionMessage('Invalid configuration: "The required component "id" is empty."');
 
         Instance::of('');
     }

--- a/tests/Di/ReflectionFactoryTest.php
+++ b/tests/Di/ReflectionFactoryTest.php
@@ -46,7 +46,7 @@ final class ReflectionFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(NotInstantiable::class);
         $this->expectExceptionMessage(
-            'Not instantiable exception: Failed to instantiate component or class: "NonExistentClass".',
+            'Not instantiable exception: "Failed to instantiate component or class: "NonExistentClass"."',
         );
 
         $this->factory->create('NonExistentClass');
@@ -96,7 +96,7 @@ final class ReflectionFactoryTest extends \PHPUnit\Framework\TestCase
 
         $this->expectException(NotInstantiable::class);
         $this->expectExceptionMessage(
-            'Not instantiable exception: Failed to instantiate component or class: "' . $interfaceClass . '".',
+            'Not instantiable exception: "Failed to instantiate component or class: "' . $interfaceClass . '"."',
         );
 
         $this->factory->create($interfaceClass);
@@ -132,7 +132,9 @@ final class ReflectionFactoryTest extends \PHPUnit\Framework\TestCase
     public function testResolveCallableDependenciesThrowsExceptionForMissingRequiredParameter(): void
     {
         $this->expectException(InvalidConfig::class);
-        $this->expectExceptionMessage('Invalid configuration: Missing required parameter "requiredParam" when calling "{closure:PHPPress\Tests\Di\ReflectionFactoryTest::testResolveCallableDependenciesThrowsExceptionForMissingRequiredParameter():137}".');
+        $this->expectExceptionMessage(
+            'Invalid configuration: "Missing required parameter "requiredParam" when calling "{closure:PHPPress\Tests\Di\ReflectionFactoryTest::testResolveCallableDependenciesThrowsExceptionForMissingRequiredParameter():139}".'
+        );
 
         $this->factory->resolveCallableDependencies(static fn(string $requiredParam) => $requiredParam);
     }
@@ -154,7 +156,7 @@ final class ReflectionFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(
-            'Not instantiable exception: Failed to instantiate component or class: "NonExistentClass".',
+            'Not instantiable exception: "Failed to instantiate component or class: "NonExistentClass"."',
         );
 
         $this->factory->resolveDependencies([Instance::of('NonExistentClass')]);

--- a/tests/Di/ReflectionFactoryTest.php
+++ b/tests/Di/ReflectionFactoryTest.php
@@ -133,7 +133,7 @@ final class ReflectionFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(InvalidConfig::class);
         $this->expectExceptionMessage(
-            'Invalid configuration: "Missing required parameter "requiredParam" when calling "{closure:PHPPress\Tests\Di\ReflectionFactoryTest::testResolveCallableDependenciesThrowsExceptionForMissingRequiredParameter():139}".'
+            'Invalid configuration: "Missing required parameter "requiredParam" when calling "{closure:PHPPress\Tests\Di\ReflectionFactoryTest::testResolveCallableDependenciesThrowsExceptionForMissingRequiredParameter():139}".',
         );
 
         $this->factory->resolveCallableDependencies(static fn(string $requiredParam) => $requiredParam);

--- a/tests/Exception/InvalidConfigTest.php
+++ b/tests/Exception/InvalidConfigTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPPress\Tests\Exception;
+
+use PHPPress\Exception\InvalidConfig;
+use PHPUnit\Framework\Attributes\Group;
+use RuntimeException;
+
+/**
+ * Test case for the InvalidConfig class.
+ *
+ * @copyright Copyright (C) 2024 PHPPress.
+ * @license GNU General Public License version 3 or later {@see LICENSE}
+ */
+#[Group('exception')]
+final class InvalidConfigTest extends \PHPUnit\Framework\TestCase
+{
+    public function testConstructor(): void
+    {
+        $exception = new InvalidConfig();
+
+        $this->assertSame('', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+
+    public function testConstructorWithFriendlyMessage(): void
+    {
+        $exception = new InvalidConfig('Test message');
+
+        $this->assertSame('Invalid configuration: "Test message"', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+
+    public function testConstructorWithArguments(): void
+    {
+        $previousException = new RuntimeException('Previous exception');
+        $exception = new InvalidConfig('Test message', 123, $previousException);
+
+        $this->assertSame('Invalid configuration: "Test message"', $exception->getMessage());
+        $this->assertSame(123, $exception->getCode());
+        $this->assertSame($previousException, $exception->getPrevious());
+    }
+}

--- a/tests/Provider/ContainerProvider.php
+++ b/tests/Provider/ContainerProvider.php
@@ -41,13 +41,13 @@ final class ContainerProvider
         return [
             [
                 Bar::class,
-                'Not instantiable exception: Missing required parameter "definitionInstance" when instantiating "'
-                . Bar::class . '".',
+                'Not instantiable exception: "Missing required parameter "definitionInstance" when instantiating "'
+                . Bar::class . '"."',
             ],
             [
                 Kappa::class,
-                'Not instantiable exception: Missing required parameter "unknown" when instantiating "'
-                . Kappa::class . '".',
+                'Not instantiable exception: "Missing required parameter "unknown" when instantiating "'
+                . Kappa::class . '"."',
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
