### PR TITLE
Enhance variadic parameter handling in constructors and add new test cases for mixed, not type hinted, and union type arguments.

### DIFF
--- a/src/Di/ReflectionFactory.php
+++ b/src/Di/ReflectionFactory.php
@@ -332,7 +332,7 @@ class ReflectionFactory
             Message::PARAMETER_CALLABLE_MISSING->getMessage(
                 $name,
                 $reflectionParameter->getDeclaringFunction()->getName(),
-            )
+            ),
         );
     }
 
@@ -354,7 +354,7 @@ class ReflectionFactory
         string|null $className,
         string $name,
         string|int $key,
-        array &$params
+        array &$params,
     ): mixed {
         if ($className === null) {
             return $this->resolveBuiltInType($reflectionParameter, $name, $params);

--- a/tests/Di/ContainerTest.php
+++ b/tests/Di/ContainerTest.php
@@ -108,11 +108,45 @@ final class ContainerTest extends \PHPUnit\Framework\TestCase
     {
         $varadicInstance = new Container()->create(
             Stub\ConstructorVaradic::class,
-            ['__construct()' => ['a', 'b', 'c']],
+            ['__construct()' => [200, 'a', 'b', 'c']],
         );
 
         $this->assertInstanceOf(Stub\ConstructorVaradic::class, $varadicInstance);
+        $this->assertsame(200, $varadicInstance->getKey());
         $this->assertSame(['a', 'b', 'c'], $varadicInstance->getValue());
+    }
+
+    public function testCreateWithConstructorVaradicMixedArguments(): void
+    {
+        $varadicInstance = new Container()->create(
+            Stub\ConstructorVaradicMixed::class,
+            ['__construct()' => [1, 'a', 2.3]],
+        );
+
+        $this->assertInstanceOf(Stub\ConstructorVaradicMixed::class, $varadicInstance);
+        $this->assertSame([1, 'a', 2.3], $varadicInstance->getValue());
+    }
+
+    public function testCreateWithConstructorVaradicNotTypeHintArguments(): void
+    {
+        $varadicInstance = new Container()->create(
+            Stub\ConstructorVaradicNotTypeHint::class,
+            ['__construct()' => [1, 'a', 2.3]],
+        );
+
+        $this->assertInstanceOf(Stub\ConstructorVaradicNotTypeHint::class, $varadicInstance);
+        $this->assertSame([1, 'a', 2.3], $varadicInstance->getValue());
+    }
+
+    public function testCreateWithConstructorVaradicUnionTypeArguments(): void
+    {
+        $varadicInstance = new Container()->create(
+            Stub\ConstructorUnionTypeVaradic::class,
+            ['__construct()' => [true, 1, 'a']],
+        );
+
+        $this->assertInstanceOf(Stub\ConstructorUnionTypeVaradic::class, $varadicInstance);
+        $this->assertSame([true, 1, 'a'], $varadicInstance->getValue());
     }
 
     public function testCreateWithDefinitions(): void

--- a/tests/Di/Stub/ConstructorUnionTypeVaradic.php
+++ b/tests/Di/Stub/ConstructorUnionTypeVaradic.php
@@ -10,18 +10,13 @@ namespace PHPPress\Tests\Di\Stub;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class ConstructorVaradic
+final class ConstructorUnionTypeVaradic
 {
     private array $value = [];
 
-    public function __construct(private int $key, string ...$value)
+    public function __construct(string|int|float|bool ...$value)
     {
         $this->value = $value;
-    }
-
-    public function getKey(): int
-    {
-        return $this->key;
     }
 
     public function getValue(): array

--- a/tests/Di/Stub/ConstructorVaradicMixed.php
+++ b/tests/Di/Stub/ConstructorVaradicMixed.php
@@ -10,18 +10,13 @@ namespace PHPPress\Tests\Di\Stub;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class ConstructorVaradic
+final class ConstructorVaradicMixed
 {
     private array $value = [];
 
-    public function __construct(private int $key, string ...$value)
+    public function __construct(mixed ...$value)
     {
         $this->value = $value;
-    }
-
-    public function getKey(): int
-    {
-        return $this->key;
     }
 
     public function getValue(): array

--- a/tests/Di/Stub/ConstructorVaradicNotTypeHint.php
+++ b/tests/Di/Stub/ConstructorVaradicNotTypeHint.php
@@ -10,18 +10,13 @@ namespace PHPPress\Tests\Di\Stub;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class ConstructorVaradic
+final class ConstructorVaradicNotTypeHint
 {
     private array $value = [];
 
-    public function __construct(private int $key, string ...$value)
+    public function __construct(...$value)
     {
         $this->value = $value;
-    }
-
-    public function getKey(): int
-    {
-        return $this->key;
     }
 
     public function getValue(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
