### PR TITLE
Update documentation to replace `[[ ]]` with `{ }` for method references in comments.

### DIFF
--- a/src/Di/Container.php
+++ b/src/Di/Container.php
@@ -247,11 +247,11 @@ class Container implements ContainerInterface
     /**
      * Returns an instance of the requested class.
      *
-     * Note that if the class is declared to be singleton by calling [[setSingleton()]], the same instance of the class
+     * Note that if the class is declared to be singleton by calling {setSingleton()}, the same instance of the class
      * will be returned each time this method is called.
      *
      * @param string $id The class Instance, name, or an alias name (e.g. `foo`) that was previously registered
-     * via [[set()]] or [[setSingleton()]].
+     * via {set()} or {setSingleton()}.
      *
      * @throws InvalidDefinition If the class cannot be recognized or correspond to an invalid definition.
      * @throws NotInstantiable If resolved to an abstract class or an interface.

--- a/src/Di/Instance.php
+++ b/src/Di/Instance.php
@@ -10,7 +10,7 @@ use PHPPress\Exception\InvalidArgument;
 /**
  * Instance represents a reference to a named object in a dependency injection (DI) container or a service locator.
  *
- * You may use [[get()]] to get the actual object referenced by [[id]].
+ * You may use {get()} to get the actual object referenced by {id}.
  *
  * Instance is mainly used in two places:
  *

--- a/src/Helper/AbstractArray.php
+++ b/src/Helper/AbstractArray.php
@@ -8,7 +8,7 @@ use function array_all;
 use function is_string;
 
 /**
- * Provides concrete implementation for [[Arr]].
+ * Provides concrete implementation for {Arr}.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}

--- a/src/Helper/AbstractConfigure.php
+++ b/src/Helper/AbstractConfigure.php
@@ -8,7 +8,7 @@ use function str_ends_with;
 use function substr;
 
 /**
- * Provides concrete implementation for [[Configure]].
+ * Provides concrete implementation for {Configure}.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}

--- a/src/Helper/AbstractPropertyAccess.php
+++ b/src/Helper/AbstractPropertyAccess.php
@@ -12,7 +12,7 @@ use function method_exists;
 use function property_exists;
 
 /**
- * Provides concrete implementation for [[PropertyAccess]].
+ * Provides concrete implementation for {PropertyAccess}.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
