### PR TITLE
Update documentation in `AbstractArray::class` and `ArrTest::class` to use `{@see}` syntax for class references.

### DIFF
--- a/src/Helper/AbstractArray.php
+++ b/src/Helper/AbstractArray.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace PHPPress\Helper;
 
 use function array_all;
+use function array_is_list;
 use function is_string;
 
 /**
- * Provides concrete implementation for {Arr}.
+ * Provides concrete implementation for {@see Arr}.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}

--- a/tests/Helper/ArrTest.php
+++ b/tests/Helper/ArrTest.php
@@ -9,7 +9,7 @@ use PHPPress\Tests\Provider\ArrProvider;
 use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 
 /**
- * Test case for the Arr class.
+ * Test case for the {@see Arr} class.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
