### PR TITLE
Update test case documentation to use `{@see}` syntax for exception classes.

### DIFF
--- a/tests/Exception/InvalidArgumentTest.php
+++ b/tests/Exception/InvalidArgumentTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**
- * Test case for the InvalidArgument class.
+ * Test case for the {@see InvalidArgument} class.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}

--- a/tests/Exception/InvalidCallTest.php
+++ b/tests/Exception/InvalidCallTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**
- * Test case for the InvalidCall class.
+ * Test case for the {@see InvalidCall} class.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}

--- a/tests/Exception/InvalidConfigTest.php
+++ b/tests/Exception/InvalidConfigTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**
- * Test case for the InvalidConfig class.
+ * Test case for the {@see InvalidConfig} class.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}

--- a/tests/Exception/InvalidDefinitionTest.php
+++ b/tests/Exception/InvalidDefinitionTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**
- * Test case for the InvalidDefinition class.
+ * Test case for the {@see InvalidDefinition} class.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}

--- a/tests/Exception/UnknownMethodTest.php
+++ b/tests/Exception/UnknownMethodTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**
- * Test case for the UnknownMethod class.
+ * Test case for the {@see UnknownMethod} class.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}

--- a/tests/Exception/UnknownPropertyTest.php
+++ b/tests/Exception/UnknownPropertyTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**
- * Test case for the UnknownProperty class.
+ * Test case for the {@see UnknownProperty} class.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
