### PR TITLE
Update documentation to use `{@see}` syntax for class and method references in helper classes.

### DIFF
--- a/src/Helper/AbstractConfigure.php
+++ b/src/Helper/AbstractConfigure.php
@@ -8,7 +8,7 @@ use function str_ends_with;
 use function substr;
 
 /**
- * Provides concrete implementation for {Configure}.
+ * Provides concrete implementation for {@see Configure}.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}

--- a/src/Helper/AbstractPropertyAccess.php
+++ b/src/Helper/AbstractPropertyAccess.php
@@ -12,7 +12,7 @@ use function method_exists;
 use function property_exists;
 
 /**
- * Provides concrete implementation for {PropertyAccess}.
+ * Provides concrete implementation for {@see PropertyAccess}.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
@@ -30,7 +30,7 @@ abstract class AbstractPropertyAccess
      *
      * @return mixed The property value.
      *
-     * @see set()
+     * {@see set()}
      */
     public static function get(object $object, string $name): mixed
     {
@@ -75,7 +75,7 @@ abstract class AbstractPropertyAccess
      *
      * @return bool Whether the named property is set (not `null`).
      *
-     * @see https://www.php.net/manual/en/function.isset.php
+     * {@see https://www.php.net/manual/en/function.isset.php}
      */
     public static function isset(object $object, string $name): bool
     {
@@ -115,7 +115,7 @@ abstract class AbstractPropertyAccess
      *
      * @return bool `true` if the property can be read, `false` otherwise.
      *
-     * @see isWritable()
+     * {@see isWritable()}
      */
     public static function isReadable(object $object, string $name, bool $stricMode = true): bool
     {
@@ -161,7 +161,7 @@ abstract class AbstractPropertyAccess
      * @throws InvalidCall If the property is read-only.
      * @throws UnknownProperty If the property is not defined.
      *
-     * @see get()
+     * {@see get()}
      */
     public static function set(object $object, string $name, mixed $value): void
     {
@@ -188,7 +188,7 @@ abstract class AbstractPropertyAccess
      * @throws InvalidCall If the property is read only.
      * @throws UnknownProperty If the property is unknown.
      *
-     * @see https://www.php.net/manual/en/function.unset.php
+     * {@see https://www.php.net/manual/en/function.unset.php}
      */
     public static function unset(object $object, string $name): void
     {

--- a/tests/Helper/ConfigureTest.php
+++ b/tests/Helper/ConfigureTest.php
@@ -8,7 +8,7 @@ use PHPPress\Helper\Configure;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
- * Test case for the Configure class.
+ * Test case for the {@see Configure} class.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
@@ -43,8 +43,13 @@ final class ConfigureTest extends \PHPUnit\Framework\TestCase
             $object,
             [
                 'property' => 'value',
-                'setMethod()' => ['param1', 'param2'],
-                'withImmutableProperty()' => [2],
+                'setMethod()' => [
+                    'param1',
+                    'param2',
+                ],
+                'withImmutableProperty()' => [
+                    2,
+                ],
             ],
         );
 

--- a/tests/Helper/PropertyAccessTest.php
+++ b/tests/Helper/PropertyAccessTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 
 /**
- * Test case for the PropertyAccess class.
+ * Test case for the {@see PropertyAccess} class.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
