### PR TITLE
Rename classes from `Invokeable` to `Invokable` for consistency and clarity in naming.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,3 +14,6 @@ parameters:
             identifier: trait.unused
         -
             identifier: catch.neverThrown
+        -
+            identifier: method.templateTypeNotInParameter
+

--- a/src/Base/MagicMethod.php
+++ b/src/Base/MagicMethod.php
@@ -60,7 +60,7 @@ trait MagicMethod
      *
      * @return bool Whether the named property is set (not `null`).
      *
-     * {@link {https://www.php.net/manual/en/function.isset.php}}
+     * {@link https://www.php.net/manual/en/function.isset.php}
      */
     public function __isset(string $name): bool
     {
@@ -98,6 +98,7 @@ trait MagicMethod
      * @param string $name The property name.
      *
      * @throws InvalidCall If the property is read only.
+     * @throws UnknownProperty If the property is not defined.
      *
      * {@link https://www.php.net/manual/en/function.unset.php}
      */

--- a/src/Di/Container.php
+++ b/src/Di/Container.php
@@ -106,11 +106,12 @@ class Container implements ContainerInterface
      *
      * @throws InvalidDefinition If the requested dependency has an invalid configuration.
      * @throws NotInstantiable If the requested dependency is an abstract class or an interface.
+     * @throws Throwable In case of circular references.
      *
      * @return mixed The fully resolved and instantiated dependency.
      *
      * @phpstan-template T
-     * @phpstan-param class-string<T> $id
+     * @phpstan-param class-string<T>|string $id
      * @phpstan-return T
      */
     public function get(string $id): mixed
@@ -125,8 +126,8 @@ class Container implements ContainerInterface
     /**
      * Returns the list of the object definitions or the loaded shared objects.
      *
-     * @return array The list of the object definitions or the loaded shared objects (type or 'id' => definition or
-     * instance).
+     * @return array The list of the object definitions or the loaded shared objects
+     * (type or 'id' => definition or instance).
      */
     public function getDefinitions(): array
     {

--- a/src/Di/Definition/Instance.php
+++ b/src/Di/Definition/Instance.php
@@ -21,9 +21,11 @@ use PHPPress\Exception\InvalidArgument;
  *     [
  *         'engine-one' => Stub\EngineMarkOne::class,
  *         'engine-two' => Stub\EngineMarkTwo::class,
- *             'instance' => [
- *                 '__class' => Stub\ConstructorVariadic::class,
- *                 '__construct()' => [Instance::of('engine-one'), Instance::of('engine-two')],
+ *         'instance' => [
+ *             '__class' => Stub\ConstructorVariadic::class,
+ *             '__construct()' => [
+ *                 Instance::of('engine-one'),
+ *                 Instance::of('engine-two'),
  *             ],
  *         ],
  *     ],
@@ -38,7 +40,7 @@ readonly class Instance
     /**
      * @throws InvalidArgument if `$id` is an empty string.
      */
-    final public function __construct(public readonly string $id)
+    final public function __construct(public string $id)
     {
         if ($id === '') {
             throw new InvalidArgument('The required component "id" is empty.');

--- a/src/Factory/ReflectionFactory.php
+++ b/src/Factory/ReflectionFactory.php
@@ -246,7 +246,6 @@ class ReflectionFactory
      *
      * @throws Exception\NotInstantiable If the class cannot be instantiated.
      * @throws InvalidDefinition If the method is not accessible or not found.
-     * @throws ReflectionException If reflection fails.
      *
      * @return object Configured object.
      */
@@ -532,6 +531,7 @@ class ReflectionFactory
      *
      * @throws Exception\NotInstantiable For instantiation failures.
      * @throws InvalidDefinition For unresolvable dependencies.
+     * @throws ReflectionException For reflection failures.
      *
      * @return array Fully resolved dependencies.
      */

--- a/src/Helper/AbstractPropertyAccess.php
+++ b/src/Helper/AbstractPropertyAccess.php
@@ -81,13 +81,13 @@ abstract class AbstractPropertyAccess
     {
         $getter = "get{$name}";
 
-        return static::hasMethod($object, $getter) ? $object->$getter() !== null : false;
+        return static::hasMethod($object, $getter) && $object->$getter() !== null;
     }
 
     /**
      * Checks if a class is a subclass of another class.
      *
-     * This method is similar to the `is_subclass_of()` function, but it does not trigger autoloading of classes.
+     * This method is similar to the `is_subclass_of()` function, but it does not trigger autoload of classes.
      * Unlike the `instanceof` operator, this method works with both objects and class names.
      *
      * @param object|string $object The object or class name to check.
@@ -107,21 +107,21 @@ abstract class AbstractPropertyAccess
      * A property is considered readable if:
      *
      * - The class has a getter method for the specified property name  (property name is case-insensitive);
-     * - The class has a member variable with the specified name (when `$stricMode` is `false`);
+     * - The class has a member variable with the specified name (when `$strictMode` is `false`);
      *
      * @param object $object The object to check for property readability.
      * @param string $name The name of the property to check.
-     * @param bool $stricMode Whether to consider member variables as readable properties. Defaults to `true`.
+     * @param bool $strictMode Whether to consider member variables as readable properties. Defaults to `true`.
      *
      * @return bool `true` if the property can be read, `false` otherwise.
      *
      * {@see isWritable()}
      */
-    public static function isReadable(object $object, string $name, bool $stricMode = true): bool
+    public static function isReadable(object $object, string $name, bool $strictMode = true): bool
     {
         $getter = "get{$name}";
 
-        return $stricMode === false
+        return $strictMode === false
             ? static::hasMethod($object, $getter)
             : self::propertyExists($object, $name) && static::hasMethod($object, $getter);
     }
@@ -132,21 +132,21 @@ abstract class AbstractPropertyAccess
      * A property is considered writable if:
      *
      * - The class has a setter method for the specified property name (property name is case-insensitive);
-     * - The class has a member variable with the specified name (when `$stricMode` is `true`);
+     * - The class has a member variable with the specified name (when `$strictMode` is `true`);
      *
-     * @param object $object The object to check for property writability.
+     * @param object $object The object to check for property writ-ability.
      * @param string $name The name of the property to check.
-     * @param bool $stricMode Whether to consider member variables as writable properties. Defaults to `true`.
+     * @param bool $strictMode Whether to consider member variables as writable properties. Defaults to `true`.
      *
      * @return bool `true` if the property can be written, `false` otherwise.
      *
      * @see isReadable()
      */
-    public static function isWritable(object $object, string $name, bool $stricMode = true): bool
+    public static function isWritable(object $object, string $name, bool $strictMode = true): bool
     {
         $setter = "set{$name}";
 
-        return $stricMode === false
+        return $strictMode === false
             ? static::hasMethod($object, $setter)
             : self::propertyExists($object, $name) && static::hasMethod($object, $setter);
     }

--- a/tests/Di/ConstructorTest.php
+++ b/tests/Di/ConstructorTest.php
@@ -602,7 +602,7 @@ final class ConstructorTest extends \PHPUnit\Framework\TestCase
                             3,
                         ],
                         $object,
-                        'InvokeableVariadicSeveralArguments',
+                        'InvokableVariadicSeveralArguments',
                         new Stub\EngineMarkOne(),
                         new Stub\EngineMarkTwo(),
                     ],
@@ -621,7 +621,7 @@ final class ConstructorTest extends \PHPUnit\Framework\TestCase
                     3,
                 ],
                 'object' => $object,
-                'string' => 'InvokeableVariadicSeveralArguments',
+                'string' => 'InvokableVariadicSeveralArguments',
                 'variadic' => [
                     'Mark One',
                     'Mark Two',
@@ -771,7 +771,7 @@ final class ConstructorTest extends \PHPUnit\Framework\TestCase
                             3,
                         ],
                         'object' => $object,
-                        'string' => 'InvokeableVariadicSeveralArguments',
+                        'string' => 'InvokableVariadicSeveralArguments',
                         'variadic' => [
                             new Stub\EngineMarkOne(),
                             new Stub\EngineMarkTwo(),
@@ -792,7 +792,7 @@ final class ConstructorTest extends \PHPUnit\Framework\TestCase
                     3,
                 ],
                 'object' => $object,
-                'string' => 'InvokeableVariadicSeveralArguments',
+                'string' => 'InvokableVariadicSeveralArguments',
                 'variadic' => [
                     'Mark One',
                     'Mark Two',
@@ -816,7 +816,7 @@ final class ConstructorTest extends \PHPUnit\Framework\TestCase
                             new Stub\EngineMarkTwo(),
                         ],
                         'object' => $object,
-                        'string' => 'InvokeableVariadicSeveralArguments',
+                        'string' => 'InvokableVariadicSeveralArguments',
                         'array' => [
                             1,
                             2,
@@ -838,7 +838,7 @@ final class ConstructorTest extends \PHPUnit\Framework\TestCase
                     3,
                 ],
                 'object' => $object,
-                'string' => 'InvokeableVariadicSeveralArguments',
+                'string' => 'InvokableVariadicSeveralArguments',
                 'variadic' => [
                     'Mark One',
                     'Mark Two',

--- a/tests/Di/InvokableTest.php
+++ b/tests/Di/InvokableTest.php
@@ -9,14 +9,17 @@ use DateTime;
 use PHPPress\Di\Container;
 use PHPPress\Di\Definition\Instance;
 use PHPPress\Exception\{InvalidArgument, InvalidDefinition};
+use PHPPress\Factory\Exception\NotInstantiable;
 use PHPUnit\Framework\Attributes\Group;
 use Psr\Container\ContainerInterface;
+use stdClass;
+use Throwable;
 
 /**
- * Test case for the {@see Container} class for invokeable class handling in the dependency injection.
+ * Test case for the {@see Container} class for invokable class handling in the dependency injection.
  *
  * Tests container's capabilities for:
- * - Auto-wiring invokeable classes
+ * - Auto-wiring invokable classes
  * - Handling default values.
  * - Handling various parameter types (scalar, compound, union, intersection).
  * - Managing variadic arguments.
@@ -28,15 +31,20 @@ use Psr\Container\ContainerInterface;
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
 #[Group('di')]
-final class InvokeableTest extends \PHPUnit\Framework\TestCase
+final class InvokableTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testAutoWiredUsingDefinition(): void
     {
         $container = $this->createContainer(
             [
                 Stub\EngineInterface::class => Stub\EngineMarkTwo::class,
                 'instance' => [
-                    '__class' => Stub\Invokeable::class,
+                    '__class' => Stub\Invokable::class,
                 ],
             ],
         );
@@ -47,12 +55,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Mark Two', $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs..
+     */
     public function testAutoWiredUsingSingleton(): void
     {
         $container = $this->createContainer(
             singletons: [
                 Stub\EngineInterface::class => Stub\EngineMarkTwo::class,
-                'instance' => Stub\Invokeable::class,
+                'instance' => Stub\Invokable::class,
             ],
         );
 
@@ -62,21 +75,31 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Mark Two', $instance);
     }
 
-    public function testBuiltInPHPClassUsingInstatiableClass(): void
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
+    public function testBuiltInPHPClassUsingInstantiableClass(): void
     {
         $container = $this->createContainer();
 
-        $instance = $container->get(Stub\InvokeableBuiltInPHPClass::class);
+        $instance = $container->get(Stub\InvokableBuiltInPHPClass::class);
 
         $this->assertInstanceOf(DateTime::class, $instance);
     }
 
-    public function testBuiltInPHPClassUsingInstatiableClassAndIndexedParameters(): void
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
+    public function testBuiltInPHPClassUsingInstantiableClassAndIndexedParameters(): void
     {
         $dateTime = new DateTime('2024-01-01');
         $container = $this->createContainer(
             [
-                Stub\InvokeableBuiltInPHPClass::class => [
+                Stub\InvokableBuiltInPHPClass::class => [
                     '__invoke()' => [
                         $dateTime,
                     ],
@@ -85,18 +108,23 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         );
 
         /** @var DateTime $instance */
-        $instance = $container->get(Stub\InvokeableBuiltInPHPClass::class);
+        $instance = $container->get(Stub\InvokableBuiltInPHPClass::class);
 
-        $this->assertInstanceOf(Datetime::class, $instance);
+        $this->assertInstanceOf(DateTime::class, $instance);
         $this->assertSame('2024-01-01', $instance->format('Y-m-d'));
     }
 
-    public function testBuiltInPHPClassUsingInstatiableClassAndNamedParameters(): void
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
+    public function testBuiltInPHPClassUsingInstantiableClassAndNamedParameters(): void
     {
         $dateTime = new DateTime('2024-01-01');
         $container = $this->createContainer(
             [
-                Stub\InvokeableBuiltInPHPClass::class => [
+                Stub\InvokableBuiltInPHPClass::class => [
                     '__invoke()' => [
                         'dateTime' => $dateTime,
                     ],
@@ -105,19 +133,24 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         );
 
         /** @var DateTime $instance */
-        $instance = $container->get(Stub\InvokeableBuiltInPHPClass::class);
+        $instance = $container->get(Stub\InvokableBuiltInPHPClass::class);
 
-        $this->assertInstanceOf(Datetime::class, $instance);
+        $this->assertInstanceOf(DateTime::class, $instance);
         $this->assertSame('2024-01-01', $instance->format('Y-m-d'));
     }
 
-    public function testBuiltInPHPClassUsingNotInstatiableClass(): void
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
+    public function testBuiltInPHPClassUsingNotInstantiableClass(): void
     {
         $arrayIterator = new ArrayIterator();
 
         $container = $this->createContainer(
             [
-                Stub\InvokeableBuiltInPHPClassOptional::class => [
+                Stub\InvokableBuiltInPHPClassOptional::class => [
                     '__invoke()' => [
                         $arrayIterator,
                     ],
@@ -125,51 +158,71 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
             ],
         );
 
-        $instance = $container->get(Stub\InvokeableBuiltInPHPClassOptional::class);
+        $instance = $container->get(Stub\InvokableBuiltInPHPClassOptional::class);
 
         $this->assertSame(['iterator' => $arrayIterator], $instance);
     }
 
-    public function testBuiltInPHPClassUsingNotInstatiableClassAndOptionalArguments(): void
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
+    public function testBuiltInPHPClassUsingNotInstantiableClassAndOptionalArguments(): void
     {
         $container = $this->createContainer();
 
-        $instance = $container->get(Stub\InvokeableBuiltInPHPClassOptional::class);
+        $instance = $container->get(Stub\InvokableBuiltInPHPClassOptional::class);
 
         $this->assertSame(['iterator' => null], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefaultValueArguments(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableDefaultValue::class,
+                    '__class' => Stub\InvokableDefaultValue::class,
                 ],
             ],
         );
 
         $instance = $container->get('instance');
 
-        $this->assertSame(['class' => 'InvokeableDefaultValue', 'engine' => null], $instance);
+        $this->assertSame(['class' => 'InvokableDefaultValue', 'engine' => null], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefaultValueArgumentsUsingAutoWired(): void
     {
         $container = $this->createContainer(
             [
                 Stub\EngineInterface::class => Stub\EngineMarkOne::class,
                 'instance' => [
-                    '__class' => Stub\InvokeableDefaultValue::class,
+                    '__class' => Stub\InvokableDefaultValue::class,
                 ],
             ],
         );
 
         $instance = $container->get('instance');
 
-        $this->assertSame(['class' => 'InvokeableDefaultValue', 'engine' => 'Mark One'], $instance);
+        $this->assertSame(['class' => 'InvokableDefaultValue', 'engine' => 'Mark One'], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingArrayCallable(): void
     {
         $container = $this->createContainer(
@@ -187,12 +240,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(42, $instance->getA());
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingArrayObjectCallable(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    new Stub\InvokeablePSRContainer(),
+                    new Stub\InvokablePSRContainer(),
                     '__invoke',
                 ],
             ],
@@ -203,6 +261,11 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(ContainerInterface::class, $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingClosure(): void
     {
         $container = $this->createContainer(
@@ -219,11 +282,15 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $instance = $container->get('instance');
 
         $this->assertInstanceOf(Stub\EngineCarTunning::class, $instance);
-        $this->assertInstanceOf(Stub\EngineCar::class, $instance->getEngineCar());
         $this->assertInstanceOf(Stub\EngineMarkOne::class, $instance->getEngineCar()->getEngine());
         $this->assertSame('Mark One', $instance->getEngineCar()->getEngineName());
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingClosureWithPSRContainerInterfaceClass(): void
     {
         $container = $this->createContainer(
@@ -241,17 +308,21 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $instance = $container->get('instance');
 
         $this->assertInstanceOf(Stub\EngineCarTunning::class, $instance);
-        $this->assertInstanceOf(Stub\EngineCar::class, $instance->getEngineCar());
         $this->assertInstanceOf(Stub\EngineMarkTwo::class, $instance->getEngineCar()->getEngine());
         $this->assertSame('Mark Two', $instance->getEngineCar()->getEngineName());
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingIndexedParameters(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\Invokeable::class,
+                    '__class' => Stub\Invokable::class,
                     '__invoke()' => [
                         new Stub\EngineMarkTwo(),
                     ],
@@ -264,15 +335,20 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Mark Two', $instance);
     }
 
-    public function testDefinitionUsingIndexedParametersAndCompundTypeArguments(): void
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
+    public function testDefinitionUsingIndexedParametersAndCompoundTypeArguments(): void
     {
-        $object = new \stdClass();
+        $object = new stdClass();
         $callable = static fn() => 'callable';
 
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableCompundType::class,
+                    '__class' => Stub\InvokableCompoundType::class,
                     '__invoke()' => [
                         [
                             1,
@@ -291,13 +367,18 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['array' => [1, 2, 3], 'callable' => $callable, 'object' => $object], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingIndexedParametersAndInstanceClassArguments(): void
     {
         $container = $this->createContainer(
             [
                 'engine-one' => Stub\EngineMarkOne::class,
                 'instance' => [
-                    '__class' => Stub\Invokeable::class,
+                    '__class' => Stub\Invokable::class,
                     '__invoke()' => [
                         Instance::of('engine-one'),
                     ],
@@ -310,12 +391,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Mark One', $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingIndexedParametersAndScalarTypeArguments(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableScalarType::class,
+                    '__class' => Stub\InvokableScalarType::class,
                     '__invoke()' => [
                         false,
                         100,
@@ -331,15 +417,20 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['bool' => false, 'int' => 100, 'float' => 2.30, 'string' => 'scalar'], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingIndexedParametersAndSeveralArguments(): void
     {
         $callable = static fn(): string => 'callable';
-        $object = new \stdClass();
+        $object = new stdClass();
 
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableSeveralArguments::class,
+                    '__class' => Stub\InvokableSeveralArguments::class,
                     '__invoke()' => [
                         [
                             1,
@@ -348,7 +439,7 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                         ],
                         $callable,
                         $object,
-                        'InvokeableVariadicSeveralArguments',
+                        'InvokableVariadicSeveralArguments',
                         new Stub\EngineMarkTwo(),
                     ],
                 ],
@@ -366,19 +457,24 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                 ],
                 'callable' => $callable,
                 'object' => $object,
-                'string' => 'InvokeableVariadicSeveralArguments',
+                'string' => 'InvokableVariadicSeveralArguments',
                 'engine' => 'Mark Two',
             ],
             $instance,
         );
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingIndexedParametersAndWithoutTypeHintArguments(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableWithoutTypeHint::class,
+                    '__class' => Stub\InvokableWithoutTypeHint::class,
                     '__invoke()' => [
                         42,
                     ],
@@ -391,12 +487,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(42, $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingNamedParameters(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\Invokeable::class,
+                    '__class' => Stub\Invokable::class,
                     '__invoke()' => [
                         'engine' => new Stub\EngineMarkOne(),
                     ],
@@ -409,15 +510,20 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Mark One', $instance);
     }
 
-    public function testDefinitionUsingNamedParametersAndCompundTypeArguments(): void
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
+    public function testDefinitionUsingNamedParametersAndCompoundTypeArguments(): void
     {
-        $object = new \stdClass();
+        $object = new stdClass();
         $callable = static fn() => 'callable';
 
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableCompundType::class,
+                    '__class' => Stub\InvokableCompoundType::class,
                     '__invoke()' => [
                         'array' => [
                             1,
@@ -436,13 +542,18 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['array' => [1, 2, 3], 'callable' => $callable, 'object' => $object], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingNamedParametersAndInstanceClassArguments(): void
     {
         $container = $this->createContainer(
             [
                 'engine-one' => Stub\EngineMarkOne::class,
                 'instance' => [
-                    '__class' => Stub\Invokeable::class,
+                    '__class' => Stub\Invokable::class,
                     '__invoke()' => [
                         'engine' => Instance::of('engine-one'),
                     ],
@@ -455,12 +566,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Mark One', $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingNamedParametersAndScalarTypeArguments(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableScalarType::class,
+                    '__class' => Stub\InvokableScalarType::class,
                     '__invoke()' => [
                         'bool' => false,
                         'int' => 100,
@@ -476,15 +592,20 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['bool' => false, 'int' => 100, 'float' => 2.30, 'string' => 'scalar'], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingNamedParametersAndSeveralArguments(): void
     {
         $callable = static fn(): string => 'callable';
-        $object = new \stdClass();
+        $object = new stdClass();
 
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableSeveralArguments::class,
+                    '__class' => Stub\InvokableSeveralArguments::class,
                     '__invoke()' => [
                         'array' => [
                             1,
@@ -493,7 +614,7 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                         ],
                         'callable' => $callable,
                         'object' => $object,
-                        'string' => 'InvokeableVariadicSeveralArguments',
+                        'string' => 'InvokableVariadicSeveralArguments',
                         'engine' => new Stub\EngineMarkTwo(),
                     ],
                 ],
@@ -511,22 +632,27 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                 ],
                 'callable' => $callable,
                 'object' => $object,
-                'string' => 'InvokeableVariadicSeveralArguments',
+                'string' => 'InvokableVariadicSeveralArguments',
                 'engine' => 'Mark Two',
             ],
             $instance,
         );
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingNamedParametersAndSeveralArgumentsDisordered(): void
     {
         $callable = static fn(): string => 'callable';
-        $object = new \stdClass();
+        $object = new stdClass();
 
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableSeveralArguments::class,
+                    '__class' => Stub\InvokableSeveralArguments::class,
                     '__invoke()' => [
                         'engine' => new Stub\EngineMarkTwo(),
                         'callable' => $callable,
@@ -536,7 +662,7 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                             3,
                         ],
                         'object' => $object,
-                        'string' => 'InvokeableVariadicSeveralArguments',
+                        'string' => 'InvokableVariadicSeveralArguments',
                     ],
                 ],
             ],
@@ -553,19 +679,24 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                 ],
                 'callable' => $callable,
                 'object' => $object,
-                'string' => 'InvokeableVariadicSeveralArguments',
+                'string' => 'InvokableVariadicSeveralArguments',
                 'engine' => 'Mark Two',
             ],
             $instance,
         );
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testDefinitionUsingNamedParametersAndWithoutTypeHintArguments(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableWithoutTypeHint::class,
+                    '__class' => Stub\InvokableWithoutTypeHint::class,
                     '__invoke()' => [
                         'value' => 42,
                     ],
@@ -578,6 +709,11 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(42, $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testFailsForDefinitionUsingClosureWithMissingRequiredParameter(): void
     {
         $container = $this->createContainer(
@@ -587,17 +723,22 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->expectException(InvalidDefinition::class);
-        $this->expectExceptionMessage('Invalid definition: "Missing required parameter "requiredParam" when calling "{closure:PHPPress\Tests\Di\InvokeableTest::testFailsForDefinitionUsingClosureWithMissingRequiredParameter():585}"."');
+        $this->expectExceptionMessage('Invalid definition: "Missing required parameter "requiredParam" when calling "{closure:PHPPress\Tests\Di\InvokableTest::testFailsForDefinitionUsingClosureWithMissingRequiredParameter():721}"."');
 
         $container->get('instance');
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testFailsForInvalidArguments(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\Invokeable::class,
+                    '__class' => Stub\Invokable::class,
                     '__invoke()' => [
                         42,
                     ],
@@ -607,17 +748,22 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
 
         $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage(
-            'Invalid argument: "PHPPress\Tests\Di\Stub\Invokeable::__invoke(): Argument #1 ($engine) must be of type PHPPress\Tests\Di\Stub\EngineInterface, int given',
+            'Invalid argument: "PHPPress\Tests\Di\Stub\Invokable::__invoke(): Argument #1 ($engine) must be of type PHPPress\Tests\Di\Stub\EngineInterface, int given',
         );
 
         $container->get('instance');
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testFailsForInvalidArgumentsFormat(): void
     {
         $container = $this->createContainer(
             [
-                Stub\InvokeableSeveralArguments::class => [
+                Stub\InvokableSeveralArguments::class => [
                     '__invoke()' => [
                         [
                             1,
@@ -625,7 +771,7 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                             3,
                         ],
                         'callable' => static fn(): string => 'callable',
-                        'object' => new \stdClass(),
+                        'object' => new stdClass(),
                         'engine' => new Stub\EngineMarkOne(),
                     ],
                 ],
@@ -637,9 +783,14 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
             'Invalid definition: "Dependencies indexed by name and by position in the same array are not allowed.',
         );
 
-        $container->get(Stub\InvokeableSeveralArguments::class);
+        $container->get(Stub\InvokableSeveralArguments::class);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testFailsForInvalidArgumentsMissingRequired(): void
     {
         $container = $this->createContainer();
@@ -649,9 +800,14 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
             'Invalid definition: "Missing required parameter "array" when calling "__invoke"."',
         );
 
-        $container->get(Stub\InvokeableSeveralArguments::class);
+        $container->get(Stub\InvokableSeveralArguments::class);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testFailsForInvalidArgumentsUnboundDependencies(): void
     {
         $container = $this->createContainer();
@@ -661,9 +817,14 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
             'Invalid definition: "Missing required parameter "firstDependency" when calling "__invoke"."',
         );
 
-        $container->get(Stub\InvokeableMultipleDependencies::class);
+        $container->get(Stub\InvokableMultipleDependencies::class);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testFailsForIntersectionTypeMissingRequired(): void
     {
         $container = $this->createContainer();
@@ -673,9 +834,14 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
             'Invalid definition: "Missing required parameter "engine" when calling "__invoke"."',
         );
 
-        $container->get(Stub\InvokeableIntersectionType::class);
+        $container->get(Stub\InvokableIntersectionType::class);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testFailsForNonExistentClass(): void
     {
         $container = $this->createContainer();
@@ -685,9 +851,14 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
             'Invalid definition: "Missing required parameter "unknownClass" when calling "__invoke"."',
         );
 
-        $container->get(Stub\InvokeableUnknownClass::class);
+        $container->get(Stub\InvokableUnknownClass::class);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testIntersectionTypeUsingDefinition(): void
     {
         $container = $this->createContainer(
@@ -701,12 +872,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
             ],
         );
 
-        $instance = $container->get(Stub\InvokeableIntersectionType::class);
+        $instance = $container->get(Stub\InvokableIntersectionType::class);
 
         $this->assertFalse($container->hasSingleton(Stub\EngineInterface::class));
         $this->assertSame('blue', $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testIntersectionTypeUsingSingleton(): void
     {
         $container = $this->createContainer(
@@ -720,12 +896,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
             ],
         );
 
-        $instance = $container->get(Stub\InvokeableIntersectionType::class);
+        $instance = $container->get(Stub\InvokableIntersectionType::class);
 
         $this->assertTrue($container->hasSingleton(Stub\EngineInterface::class));
         $this->assertSame('blue', $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testMultipleDependencies1(): void
     {
         $container = $this->createContainer(
@@ -735,11 +916,9 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
             ],
         );
 
-        $instance = $container->get(Stub\InvokeableMultipleDependencies::class);
+        $instance = $container->get(Stub\InvokableMultipleDependencies::class);
 
-        $this->assertInstanceOf(Stub\InvokeableMultipleDependencies::class, $instance);
-        $this->assertInstanceOf(Stub\EngineInterface::class, $instance->getFirstDependency());
-        $this->assertInstanceOf(Stub\InstanceInterface::class, $instance->getSecondDependency());
+        $this->assertInstanceOf(Stub\InvokableMultipleDependencies::class, $instance);
 
         $actions = $instance->performActions();
 
@@ -747,31 +926,46 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(0, $actions['second']);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testPSRContainerInterfaceArgument(): void
     {
         $container = $this->createContainer();
 
-        $instance = $container->get(Stub\InvokeablePSRContainer::class);
+        $instance = $container->get(Stub\InvokablePSRContainer::class);
 
         $this->assertInstanceOf(ContainerInterface::class, $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testRetrievesDefaultValueForOptionalArguments(): void
     {
         $container = $this->createContainer();
 
-        $instance = $container->get(Stub\InvokeableOptional::class);
+        $instance = $container->get(Stub\InvokableOptional::class);
 
         $this->assertNull($instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testRetrievesDefaultValueForOptionalArgumentsUsingDefinition(): void
     {
         $container = $this->createContainer(
             [
                 Stub\EngineInterface::class => Stub\EngineMarkOne::class,
                 'instance' => [
-                    '__class' => Stub\InvokeableOptional::class,
+                    '__class' => Stub\InvokableOptional::class,
                 ],
             ],
         );
@@ -783,13 +977,18 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Mark One', $instance->getName());
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testRetrievesDefaultValueForOptionalArgumentsUsingSingleton(): void
     {
         $container = $this->createContainer(
             singletons: [
                 Stub\EngineInterface::class => Stub\EngineMarkOne::class,
                 'instance' => [
-                    '__class' => Stub\InvokeableOptional::class,
+                    '__class' => Stub\InvokableOptional::class,
                 ],
             ],
         );
@@ -801,12 +1000,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Mark One', $instance->getName());
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testUnionTypeUsingDefinition(): void
     {
         $container = $this->createContainer(
             [
                 Stub\EngineInterface::class => Stub\EngineMarkOne::class,
-                'instance' => Stub\InvokeableUnionType::class,
+                'instance' => Stub\InvokableUnionType::class,
             ],
         );
 
@@ -816,12 +1020,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Mark One', $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testUnionTypeUsingSingleton(): void
     {
         $container = $this->createContainer(
             singletons: [
                 Stub\EngineInterface::class => Stub\EngineMarkOne::class,
-                'instance' => Stub\InvokeableUnionType::class,
+                'instance' => Stub\InvokableUnionType::class,
             ],
         );
 
@@ -831,13 +1040,18 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Mark One', $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testVariadicUsingAutoWiredDefinition(): void
     {
         $container = $this->createContainer(
             [
                 Stub\EngineInterface::class => Stub\EngineMarkTwo::class,
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadic::class,
+                    '__class' => Stub\InvokableVariadic::class,
                 ],
             ],
         );
@@ -848,13 +1062,18 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['variadic' => ['Mark Two']], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testVariadicUsingAutoWiredSingleton(): void
     {
         $container = $this->createContainer(
             singletons: [
                 Stub\EngineInterface::class => Stub\EngineMarkTwo::class,
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadic::class,
+                    '__class' => Stub\InvokableVariadic::class,
                 ],
             ],
         );
@@ -865,12 +1084,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['variadic' => ['Mark Two']], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testVariadicDefinitionWithIndexedParameters(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadic::class,
+                    '__class' => Stub\InvokableVariadic::class,
                     '__invoke()' => [
                         [
                             new Stub\EngineMarkOne(),
@@ -886,15 +1110,20 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['variadic' => ['Mark One', 'Mark Two']], $instance);
     }
 
-    public function testVariadicUsingDefinitionWithIndexedParametersAndCompundTypeArguments(): void
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
+    public function testVariadicUsingDefinitionWithIndexedParametersAndCompoundTypeArguments(): void
     {
-        $object = new \stdClass();
+        $object = new stdClass();
         $callable = static fn() => 'callable';
 
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadicCompundType::class,
+                    '__class' => Stub\InvokableVariadicCompoundType::class,
                     '__invoke()' => [
                         [
                             [
@@ -915,6 +1144,11 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['variadic' => [[false, true], $object, $callable, null]], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testVariadicUsingDefinitionWithIndexedParametersAndInstanceClassArguments(): void
     {
         $container = $this->createContainer(
@@ -922,7 +1156,7 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                 'engine-one' => Stub\EngineMarkOne::class,
                 'engine-two' => Stub\EngineMarkTwo::class,
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadic::class,
+                    '__class' => Stub\InvokableVariadic::class,
                     '__invoke()' => [
                         [
                             Instance::of('engine-one'),
@@ -938,12 +1172,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['variadic' => ['Mark One', 'Mark Two']], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testVariadicUsingDefinitionWithIndexedParametersAndScalarTypeArguments(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadicScalarType::class,
+                    '__class' => Stub\InvokableVariadicScalarType::class,
                     '__invoke()' => [
                         [
                             false,
@@ -961,15 +1200,20 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['variadic' => [false, 100, 2.30, 'variadic']], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testVariadicUsingDefinitionWithIndexedParametersAndSeveralArguments(): void
     {
         $callable = static fn(): string => 'callable';
-        $object = new \stdClass();
+        $object = new stdClass();
 
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadicSeveralArguments::class,
+                    '__class' => Stub\InvokableVariadicSeveralArguments::class,
                     '__invoke()' => [
                         [
                             1,
@@ -978,7 +1222,7 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                         ],
                         $callable,
                         $object,
-                        'InvokeableVariadicSeveralArguments',
+                        'InvokableVariadicSeveralArguments',
                         [
                             new Stub\EngineMarkOne(),
                             new Stub\EngineMarkTwo(),
@@ -999,7 +1243,7 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                 ],
                 'callable' => $callable,
                 'object' => $object,
-                'string' => 'InvokeableVariadicSeveralArguments',
+                'string' => 'InvokableVariadicSeveralArguments',
                 'variadic' => [
                     'Mark One',
                     'Mark Two',
@@ -1009,12 +1253,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testVariadicUsingDefinitionWithIndexedParametersAndWithoutTypeHintArguments(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadicWithoutTypeHint::class,
+                    '__class' => Stub\InvokableVariadicWithoutTypeHint::class,
                     '__invoke()' => [
                         [
                             false,
@@ -1032,12 +1281,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['variadic' => [false, 100, 2.30, 'variadic']], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testVariadicUsingDefinitionWithNamedParameters(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadic::class,
+                    '__class' => Stub\InvokableVariadic::class,
                     '__invoke()' => [
                         'variadic' => [
                             new Stub\EngineMarkOne(),
@@ -1053,15 +1307,20 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['variadic' => ['Mark One', 'Mark Two']], $instance);
     }
 
-    public function testVariadicUsingDefinitionWithNamedParametersAndCompundTypeArguments(): void
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
+    public function testVariadicUsingDefinitionWithNamedParametersAndCompoundTypeArguments(): void
     {
-        $object = new \stdClass();
+        $object = new stdClass();
         $callable = static fn() => 'callable';
 
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadicCompundType::class,
+                    '__class' => Stub\InvokableVariadicCompoundType::class,
                     '__invoke()' => [
                         'variadic' => [
                             [
@@ -1095,12 +1354,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testVariadicUsingDefinitionWithNamedParametersAndDefaultValueArguments(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadicDefaultValue::class,
+                    '__class' => Stub\InvokableVariadicDefaultValue::class,
                     '__invoke()' => [
                         'variadic' => [
                             new Stub\EngineMarkOne(),
@@ -1115,7 +1379,7 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(
             [
-                'class' => 'InvokeableVariadicDefaultValue',
+                'class' => 'InvokableVariadicDefaultValue',
                 'variadic' => [
                     'Mark One',
                     'Mark Two',
@@ -1125,6 +1389,11 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testVariadicUsingDefinitionWithNamedParametersAndInstanceClassArguments(): void
     {
         $container = $this->createContainer(
@@ -1132,7 +1401,7 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                 'engine-one' => Stub\EngineMarkOne::class,
                 'engine-two' => Stub\EngineMarkTwo::class,
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadic::class,
+                    '__class' => Stub\InvokableVariadic::class,
                     '__invoke()' => [
                         'variadic' => [
                             Instance::of('engine-one'),
@@ -1148,12 +1417,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['variadic' => ['Mark One', 'Mark Two']], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testVariadicUsingDefinitionWithNamedParametersAndScalarTypeArguments(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadicScalarType::class,
+                    '__class' => Stub\InvokableVariadicScalarType::class,
                     '__invoke()' => [
                         'variadic' => [
                             false,
@@ -1171,15 +1445,20 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['variadic' => [false, 100, 2.30, 'variadic']], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testVariadicUsingDefinitionWithNamedParametersAndSeveralArguments(): void
     {
         $callable = static fn(): string => 'callable';
-        $object = new \stdClass();
+        $object = new stdClass();
 
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadicSeveralArguments::class,
+                    '__class' => Stub\InvokableVariadicSeveralArguments::class,
                     '__invoke()' => [
                         'array' => [
                             1,
@@ -1188,7 +1467,7 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                         ],
                         'callable' => $callable,
                         'object' => $object,
-                        'string' => 'InvokeableVariadicSeveralArguments',
+                        'string' => 'InvokableVariadicSeveralArguments',
                         'variadic' => [
                             new Stub\EngineMarkOne(),
                             new Stub\EngineMarkTwo(),
@@ -1209,7 +1488,7 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                 ],
                 'callable' => $callable,
                 'object' => $object,
-                'string' => 'InvokeableVariadicSeveralArguments',
+                'string' => 'InvokableVariadicSeveralArguments',
                 'variadic' => [
                     'Mark One',
                     'Mark Two',
@@ -1219,15 +1498,20 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testVariadicUsingDefinitionWithNamedParametersAndSeveralArgumentsDisordered(): void
     {
         $callable = static fn(): string => 'callable';
-        $object = new \stdClass();
+        $object = new stdClass();
 
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadicSeveralArguments::class,
+                    '__class' => Stub\InvokableVariadicSeveralArguments::class,
                     '__invoke()' => [
                         'variadic' => [
                             new Stub\EngineMarkOne(),
@@ -1240,7 +1524,7 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                             3,
                         ],
                         'object' => $object,
-                        'string' => 'InvokeableVariadicSeveralArguments',
+                        'string' => 'InvokableVariadicSeveralArguments',
                     ],
                 ],
             ],
@@ -1257,7 +1541,7 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
                 ],
                 'callable' => $callable,
                 'object' => $object,
-                'string' => 'InvokeableVariadicSeveralArguments',
+                'string' => 'InvokableVariadicSeveralArguments',
                 'variadic' => [
                     'Mark One',
                     'Mark Two',
@@ -1267,12 +1551,17 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    /**
+     * @throws InvalidDefinition If the definition is invalid.
+     * @throws NotInstantiable If the class is not instantiable.
+     * @throws Throwable If an error occurs.
+     */
     public function testVariadicUsingDefinitionWithNamedParametersAndWithoutTypeHintArguments(): void
     {
         $container = $this->createContainer(
             [
                 'instance' => [
-                    '__class' => Stub\InvokeableVariadicWithoutTypeHint::class,
+                    '__class' => Stub\InvokableVariadicWithoutTypeHint::class,
                     '__invoke()' => [
                         'variadic' => [
                             false,
@@ -1290,6 +1579,9 @@ final class InvokeableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['variadic' => [false, 100, 2.30, 'variadic']], $instance);
     }
 
+    /**
+     * @throws InvalidDefinition When the definition is invalid.
+     */
     private function createContainer($definitions = [], $singletons = []): Container
     {
         return new Container($definitions, $singletons);

--- a/tests/Di/Stub/Invokable.php
+++ b/tests/Di/Stub/Invokable.php
@@ -10,7 +10,7 @@ namespace PHPPress\Tests\Di\Stub;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class Invokeable
+final class Invokable
 {
     public function __invoke(EngineInterface $engine): string
     {

--- a/tests/Di/Stub/InvokableBuiltInPHPClass.php
+++ b/tests/Di/Stub/InvokableBuiltInPHPClass.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace PHPPress\Tests\Di\Stub;
 
+use DateTime;
+
 /**
  * Stub class for testing.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableUnknownClass
+final class InvokableBuiltInPHPClass
 {
-    public function __invoke(UnknownClass $unknownClass) {}
+    public function __invoke(DateTime $dateTime): DateTime
+    {
+        return $dateTime;
+    }
 }

--- a/tests/Di/Stub/InvokableBuiltInPHPClassOptional.php
+++ b/tests/Di/Stub/InvokableBuiltInPHPClassOptional.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PHPPress\Tests\Di\Stub;
 
-use DateTime;
+use Iterator;
 
 /**
  * Stub class for testing.
@@ -12,10 +12,12 @@ use DateTime;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableBuiltInPHPClass
+final class InvokableBuiltInPHPClassOptional
 {
-    public function __invoke(DateTime $dateTime): DateTime
+    public function __invoke(Iterator|null $iterator = null): array
     {
-        return $dateTime;
+        return [
+            'iterator' => $iterator,
+        ];
     }
 }

--- a/tests/Di/Stub/InvokableCompoundType.php
+++ b/tests/Di/Stub/InvokableCompoundType.php
@@ -10,12 +10,14 @@ namespace PHPPress\Tests\Di\Stub;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableVariadicWithoutTypeHint
+final class InvokableCompoundType
 {
-    public function __invoke(...$variadic): array
+    public function __invoke(array $array, callable $callable, object|null $object): array
     {
         return [
-            'variadic' => $variadic,
+            'array' => $array,
+            'callable' => $callable,
+            'object' => $object,
         ];
     }
 }

--- a/tests/Di/Stub/InvokableDefaultValue.php
+++ b/tests/Di/Stub/InvokableDefaultValue.php
@@ -10,12 +10,13 @@ namespace PHPPress\Tests\Di\Stub;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableVariadicScalarType
+final class InvokableDefaultValue
 {
-    public function __invoke(bool|int|float|string ...$variadic): array
+    public function __invoke(string $class = 'InvokableDefaultValue', EngineInterface|null $engine = null): array
     {
         return [
-            'variadic' => $variadic,
+            'class' => $class,
+            'engine' => $engine?->getName(),
         ];
     }
 }

--- a/tests/Di/Stub/InvokableIntersectionType.php
+++ b/tests/Di/Stub/InvokableIntersectionType.php
@@ -4,18 +4,16 @@ declare(strict_types=1);
 
 namespace PHPPress\Tests\Di\Stub;
 
-use Psr\Container\ContainerInterface;
-
 /**
  * Stub class for testing.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeablePSRContainer
+final class InvokableIntersectionType
 {
-    public function __invoke(ContainerInterface $container): ContainerInterface
+    public function __invoke(EngineInterface&EngineColorInterface $engine): int|string
     {
-        return $container;
+        return $engine->getColor();
     }
 }

--- a/tests/Di/Stub/InvokableMultipleDependencies.php
+++ b/tests/Di/Stub/InvokableMultipleDependencies.php
@@ -10,7 +10,7 @@ namespace PHPPress\Tests\Di\Stub;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableMultipleDependencies
+final class InvokableMultipleDependencies
 {
     private EngineInterface $firstDependency;
     private InstanceInterface $secondDependency;

--- a/tests/Di/Stub/InvokableOptional.php
+++ b/tests/Di/Stub/InvokableOptional.php
@@ -10,10 +10,10 @@ namespace PHPPress\Tests\Di\Stub;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableWithoutTypeHint
+final class InvokableOptional
 {
-    public function __invoke($value): mixed
+    public function __invoke(EngineInterface|null $engine = null): EngineInterface|null
     {
-        return $value;
+        return $engine ? new EngineCar($engine)->getEngine() : null;
     }
 }

--- a/tests/Di/Stub/InvokablePSRContainer.php
+++ b/tests/Di/Stub/InvokablePSRContainer.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace PHPPress\Tests\Di\Stub;
 
+use Psr\Container\ContainerInterface;
+
 /**
  * Stub class for testing.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableVariadicCompundType
+final class InvokablePSRContainer
 {
-    public function __invoke(array|object|callable|null ...$variadic): array
+    public function __invoke(ContainerInterface $container): ContainerInterface
     {
-        return [
-            'variadic' => $variadic,
-        ];
+        return $container;
     }
 }

--- a/tests/Di/Stub/InvokableScalarType.php
+++ b/tests/Di/Stub/InvokableScalarType.php
@@ -10,14 +10,15 @@ namespace PHPPress\Tests\Di\Stub;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableCompundType
+final class InvokableScalarType
 {
-    public function __invoke(array $array, callable $callable, object|null $object): array
+    public function __invoke(bool $bool, int $int, float $float, string $string): array
     {
         return [
-            'array' => $array,
-            'callable' => $callable,
-            'object' => $object,
+            'bool' => $bool,
+            'int' => $int,
+            'float' => $float,
+            'string' => $string,
         ];
     }
 }

--- a/tests/Di/Stub/InvokableSeveralArguments.php
+++ b/tests/Di/Stub/InvokableSeveralArguments.php
@@ -4,32 +4,27 @@ declare(strict_types=1);
 
 namespace PHPPress\Tests\Di\Stub;
 
-use function array_map;
-
 /**
  * Stub class for testing.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableVariadicSeveralArguments
+final class InvokableSeveralArguments
 {
     public function __invoke(
         array $array,
         callable $callable,
         object $object,
         string $string,
-        EngineInterface|null ...$variadic,
+        EngineInterface|null $engine,
     ): array {
         return [
             'array' => $array,
             'callable' => $callable,
             'object' => $object,
             'string' => $string,
-            'variadic' => array_map(
-                static fn(EngineInterface|null $engine): string|null => $engine?->getName(),
-                $variadic,
-            ),
+            'engine' => $engine?->getName(),
         ];
     }
 }

--- a/tests/Di/Stub/InvokableUnionType.php
+++ b/tests/Di/Stub/InvokableUnionType.php
@@ -10,7 +10,7 @@ namespace PHPPress\Tests\Di\Stub;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableUnionType
+final class InvokableUnionType
 {
     public function __invoke(EngineColorInterface|EngineInterface $engine): string
     {

--- a/tests/Di/Stub/InvokableUnknownClass.php
+++ b/tests/Di/Stub/InvokableUnknownClass.php
@@ -10,10 +10,7 @@ namespace PHPPress\Tests\Di\Stub;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableIntersectionType
+final class InvokableUnknownClass
 {
-    public function __invoke(EngineInterface&EngineColorInterface $engine): int|string
-    {
-        return $engine->getColor();
-    }
+    public function __invoke(UnknownClass $unknownClass) {}
 }

--- a/tests/Di/Stub/InvokableVariadic.php
+++ b/tests/Di/Stub/InvokableVariadic.php
@@ -12,7 +12,7 @@ use function array_map;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableVariadic
+final class InvokableVariadic
 {
     public function __invoke(EngineInterface ...$variadic): array
     {

--- a/tests/Di/Stub/InvokableVariadicCompoundType.php
+++ b/tests/Di/Stub/InvokableVariadicCompoundType.php
@@ -10,13 +10,12 @@ namespace PHPPress\Tests\Di\Stub;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableDefaultValue
+final class InvokableVariadicCompoundType
 {
-    public function __invoke(string $class = 'InvokeableDefaultValue', EngineInterface|null $engine = null): array
+    public function __invoke(array|object|callable|null ...$variadic): array
     {
         return [
-            'class' => $class,
-            'engine' => $engine?->getName(),
+            'variadic' => $variadic,
         ];
     }
 }

--- a/tests/Di/Stub/InvokableVariadicDefaultValue.php
+++ b/tests/Di/Stub/InvokableVariadicDefaultValue.php
@@ -12,9 +12,9 @@ use function array_map;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableVariadicDefaultValue
+final class InvokableVariadicDefaultValue
 {
-    public function __invoke(string $class = 'InvokeableVariadicDefaultValue', EngineInterface ...$variadic): array
+    public function __invoke(string $class = 'InvokableVariadicDefaultValue', EngineInterface ...$variadic): array
     {
         return [
             'class' => $class,

--- a/tests/Di/Stub/InvokableVariadicScalarType.php
+++ b/tests/Di/Stub/InvokableVariadicScalarType.php
@@ -4,20 +4,18 @@ declare(strict_types=1);
 
 namespace PHPPress\Tests\Di\Stub;
 
-use Iterator;
-
 /**
  * Stub class for testing.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableBuiltInPHPClassOptional
+final class InvokableVariadicScalarType
 {
-    public function __invoke(Iterator|null $iterator = null): array
+    public function __invoke(bool|int|float|string ...$variadic): array
     {
         return [
-            'iterator' => $iterator,
+            'variadic' => $variadic,
         ];
     }
 }

--- a/tests/Di/Stub/InvokableVariadicSeveralArguments.php
+++ b/tests/Di/Stub/InvokableVariadicSeveralArguments.php
@@ -4,27 +4,32 @@ declare(strict_types=1);
 
 namespace PHPPress\Tests\Di\Stub;
 
+use function array_map;
+
 /**
  * Stub class for testing.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableSeveralArguments
+final class InvokableVariadicSeveralArguments
 {
     public function __invoke(
         array $array,
         callable $callable,
         object $object,
         string $string,
-        EngineInterface|null $engine,
+        EngineInterface|null ...$variadic,
     ): array {
         return [
             'array' => $array,
             'callable' => $callable,
             'object' => $object,
             'string' => $string,
-            'engine' => $engine?->getName(),
+            'variadic' => array_map(
+                static fn(EngineInterface|null $engine): string|null => $engine?->getName(),
+                $variadic,
+            ),
         ];
     }
 }

--- a/tests/Di/Stub/InvokableVariadicWithoutTypeHint.php
+++ b/tests/Di/Stub/InvokableVariadicWithoutTypeHint.php
@@ -10,15 +10,12 @@ namespace PHPPress\Tests\Di\Stub;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableScalarType
+final class InvokableVariadicWithoutTypeHint
 {
-    public function __invoke(bool $bool, int $int, float $float, string $string): array
+    public function __invoke(...$variadic): array
     {
         return [
-            'bool' => $bool,
-            'int' => $int,
-            'float' => $float,
-            'string' => $string,
+            'variadic' => $variadic,
         ];
     }
 }

--- a/tests/Di/Stub/InvokableWithoutTypeHint.php
+++ b/tests/Di/Stub/InvokableWithoutTypeHint.php
@@ -10,10 +10,10 @@ namespace PHPPress\Tests\Di\Stub;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-final class InvokeableOptional
+final class InvokableWithoutTypeHint
 {
-    public function __invoke(EngineInterface|null $engine = null): EngineInterface|null
+    public function __invoke($value): mixed
     {
-        return $engine ? new EngineCar($engine)->getEngine() : null;
+        return $value;
     }
 }

--- a/tests/Factory/Exception/NotInstantiableTest.php
+++ b/tests/Factory/Exception/NotInstantiableTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace PHPPress\Tests\Di\Exception;
+namespace PHPPress\Tests\Factory\Exception;
 
 use PHPPress\Factory\Exception\NotInstantiable;
 use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**
- * Test case for the NotInstantiable class.
+ * Test case for the {@see NotInstantiable} class.
  *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}

--- a/tests/Factory/ReflectionFactoryTest.php
+++ b/tests/Factory/ReflectionFactoryTest.php
@@ -5,14 +5,16 @@ declare(strict_types=1);
 namespace PHPPress\Tests\Factory;
 
 use PHPPress\Di\Container;
+use PHPPress\Exception\InvalidDefinition;
 use PHPPress\Factory\ReflectionFactory;
 use PHPUnit\Framework\Attributes\Group;
+use Throwable;
 
 /**
- * Test case for the ReflectionFactory class.
+ * Test case for the {@see ReflectionFactory} class.
  *
  * @copyright Copyright (C) 2024 PHPPress.
- * @license GNU General Public License version 3 or later {@see \PHPPress\LICENSE}
+ * @license GNU General Public License version 3 or later {@see LICENSE}
  */
 #[Group('di')]
 final class ReflectionFactoryTest extends \PHPUnit\Framework\TestCase
@@ -33,6 +35,10 @@ final class ReflectionFactoryTest extends \PHPUnit\Framework\TestCase
         parent::tearDown();
     }
 
+    /**
+     * @throws InvalidDefinition If dependencies cannot be resolved.
+     * @throws Throwable If the callback is not valid.
+     */
     public function testInvokeDefinitionUsingAdditionalParameters(): void
     {
         $invoke = $this->factory->invoke(

--- a/tests/Helper/PropertyAccessTest.php
+++ b/tests/Helper/PropertyAccessTest.php
@@ -18,6 +18,9 @@ use stdClass;
 #[Group('helpers')]
 final class PropertyAccessTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @throws UnknownProperty If the property is unknown.
+     */
     public function testFailsForGetWriteOnlyProperty(): void
     {
         $object = $this->createObject();
@@ -30,6 +33,9 @@ final class PropertyAccessTest extends \PHPUnit\Framework\TestCase
         PropertyAccess::get($object, 'writeOnly');
     }
 
+    /**
+     * @throws InvalidCall If the property is read-only.
+     */
     public function testFailsForGetUnknownProperty(): void
     {
         $object = $this->createObject();
@@ -42,6 +48,9 @@ final class PropertyAccessTest extends \PHPUnit\Framework\TestCase
         PropertyAccess::get($object, 'unknown');
     }
 
+    /**
+     * @throws UnknownProperty If the property is unknown.
+     */
     public function testFailsForSetReadOnlyProperty(): void
     {
         $object = $this->createObject();
@@ -54,6 +63,9 @@ final class PropertyAccessTest extends \PHPUnit\Framework\TestCase
         PropertyAccess::set($object, 'object', new stdClass());
     }
 
+    /**
+     * @throws InvalidCall If the property is write-only.
+     */
     public function testFailsForSetUnknownProperty(): void
     {
         $object = $this->createObject();
@@ -66,6 +78,10 @@ final class PropertyAccessTest extends \PHPUnit\Framework\TestCase
         PropertyAccess::set($object, 'unknown', 'value');
     }
 
+    /**
+     * @throws UnknownProperty If the property is unknown.
+     * @throws InvalidCall If the property is write-only.
+     */
     public function testGet(): void
     {
         $object = $this->createObject();
@@ -87,7 +103,7 @@ final class PropertyAccessTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(PropertyAccess::hasMethod($object, 'setWriteOnly'));
     }
 
-    public function testIsRedeable(): void
+    public function testIsReadable(): void
     {
         $object = $this->createObject();
 
@@ -97,7 +113,7 @@ final class PropertyAccessTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(PropertyAccess::isReadable($object, 'text'));
     }
 
-    public function testIsRedeabeUsingStrictMode(): void
+    public function testIsReadableUsingStrictMode(): void
     {
         $object = $this->createObject();
 
@@ -134,13 +150,17 @@ final class PropertyAccessTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(PropertyAccess::isWritable($object, 'text'));
     }
 
-    public function testIsWritableUsingStricMode(): void
+    public function testIsWritableUsingStrictMode(): void
     {
         $object = $this->createObject();
 
         $this->assertTrue(PropertyAccess::isWritable($object, 'writeOnly', false));
     }
 
+    /**
+     * @throws UnknownProperty If the property is unknown.
+     * @throws InvalidCall If the property is read-only.
+     */
     public function testSet(): void
     {
         $object = $this->createObject();
@@ -149,6 +169,10 @@ final class PropertyAccessTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('new text', PropertyAccess::get($object, 'text'));
     }
 
+    /**
+     * @throws UnknownProperty If the property is unknown.
+     * @throws InvalidCall If the property is read-only.
+     */
     public function testUnset(): void
     {
         $object = $this->createObject();

--- a/tests/Helper/Stub/PropertyObject.php
+++ b/tests/Helper/Stub/PropertyObject.php
@@ -27,7 +27,7 @@ final class PropertyObject extends MagicObject
         $this->text = $value;
     }
 
-    public function getObject(): object|null
+    public function getObject(): object
     {
         if ($this->object === null) {
             $this->object = new self();
@@ -39,7 +39,7 @@ final class PropertyObject extends MagicObject
 
     public function getExecute(): callable
     {
-        return function ($param) {
+        return static function ($param) {
             return $param * 2;
         };
     }

--- a/tests/Support/Assert.php
+++ b/tests/Support/Assert.php
@@ -5,16 +5,15 @@ declare(strict_types=1);
 namespace PHPPress\Tests\Support;
 
 use ReflectionClass;
+use ReflectionException;
 
+use function is_string;
 use function str_replace;
 
-/**
- * @psalm-suppress PropertyNotSetInConstructor
- */
 final class Assert
 {
     /**
-     * Asserting two strings equality ignoring line endings.
+     * Asserting two strings equalities ignoring line endings.
      *
      * @param string $expected The expected string.
      * @param string $actual The actual string.
@@ -33,6 +32,8 @@ final class Assert
      *
      * @param string|object $object The class name or object to get the property from.
      * @param string $propertyName The name of the property to get.
+     *
+     * @throws ReflectionException If the property does not exist.
      */
     public static function inaccessibleProperty(string|object $object, string $propertyName): mixed
     {
@@ -43,9 +44,7 @@ final class Assert
         }
 
         if ($propertyName !== '') {
-            $property = $reflection->getProperty($propertyName);
-
-            return $property->getValue($object);
+            return $reflection->getProperty($propertyName)->getValue($object);
         }
 
         return null;
@@ -57,6 +56,8 @@ final class Assert
      * @param string|object $object The class name or object to set the property on.
      * @param string $propertyName The name of the property to set.
      * @param mixed $value The value to set.
+     *
+     * @throws ReflectionException If the property does not exist.
      */
     public static function setInaccessibleProperty(string|object $object, string $propertyName, mixed $value): void
     {
@@ -70,7 +71,6 @@ final class Assert
 
         if ($propertyName !== '') {
             $property = $reflection->getProperty($propertyName);
-            $property->setAccessible(true);
             $property->setValue($object, $value);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
