### PR TITLE
Add `Emitter` interface and implement `SapiEmitter` class for PSR-7 response handling.

### DIFF
--- a/src/Http/Emitter/Emitter.php
+++ b/src/Http/Emitter/Emitter.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPPress\Http\Emitter;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Interface for emitting PSR-7 HTTP responses.
+ *
+ * Provides functionality to emit HTTP responses including status line, headers and message body according to PSR-7
+ * HTTP message specifications.
+ *
+ * @copyright Copyright (C) 2024 PHPPress.
+ * @license GNU General Public License version 3 or later {@see LICENSE}
+ */
+interface Emitter
+{
+    /**
+     * Emit a response to the output buffer.
+     *
+     * Emits the response by sending the status line, headers and message body to output. When $body is true, only
+     * headers will be emitted without the body content.
+     *
+     * @param ResponseInterface $response The PSR-7 response to emit.
+     * @param bool $body Whether to emit the response body.
+     */
+    public function emit(ResponseInterface $response, bool $body = false): void;
+}

--- a/src/Http/Emitter/SapiEmitter.php
+++ b/src/Http/Emitter/SapiEmitter.php
@@ -26,7 +26,7 @@ use function ucwords;
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
-readonly class SapiEmitter
+readonly class SapiEmitter implements Emitter
 {
     /**
      * Initialize a new SAPI Emitter instance.
@@ -56,6 +56,12 @@ readonly class SapiEmitter
      *
      * @throws Exception\HeadersAlreadySent If headers have already been sent.
      * @throws Exception\OutputAlreadySent  If content has already been emitted.
+     *
+     * ```php
+     * $emitter = new SapiEmmiter();
+     * $response = new Response();
+     * $emitter->emit($response);
+     * ```
      */
     public function emit(ResponseInterface $response, bool $body = false): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
