### PR TITLE
Add `HttpNoBodyStatus` enum and update `Emitter` classes to handle HTTP status codes without a message body.

### DIFF
--- a/src/Http/Emitter/Emitter.php
+++ b/src/Http/Emitter/Emitter.php
@@ -12,6 +12,14 @@ use Psr\Http\Message\ResponseInterface;
  * Provides functionality to emit HTTP responses including status line, headers and message body according to PSR-7
  * HTTP message specifications.
  *
+ * According to HTTP/1.1 specifications, certain status codes MUST NOT include a message body:
+ * - `1xx` (Informational): `100` Continue, `101` Switching Protocols, `102` Processing, `103` Early Hints.
+ * - `204` No Content, `205` Reset Content.
+ * - `304` Not Modified.
+ *
+ * Implementations of this interface must ensure that no body content is emitted for these status codes, regardless of
+ * whether a body is present in the response object.
+ *
  * @copyright Copyright (C) 2024 PHPPress.
  * @license GNU General Public License version 3 or later {@see LICENSE}
  */
@@ -22,6 +30,10 @@ interface Emitter
      *
      * Emits the response by sending the status line, headers and message body to output. When $body is true, only
      * headers will be emitted without the body content.
+     *
+     * Note: According to HTTP/1.1 specifications, responses with certain status codes
+     * (`100` - `103`, `204`, `205`, `304`) MUST NOT include a message body. For these status codes, the body will not
+     * be emitted even if present in the response object.
      *
      * @param ResponseInterface $response The PSR-7 response to emit.
      * @param bool $body Whether to emit the response body.

--- a/src/Http/Emitter/HttpNoBodyStatus.php
+++ b/src/Http/Emitter/HttpNoBodyStatus.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPPress\Http\Emitter;
+
+/**
+ * HTTP status codes that MUST NOT include a message body according to RFC 7231.
+ *
+ * @see https://tools.ietf.org/html/rfc7231
+ */
+enum HttpNoBodyStatus: int
+{
+    /**
+     * 1xx (Informational): The request was received, continuing process.
+     */
+    case CONTINUE = 100;
+    case SWITCHING_PROTOCOLS = 101;
+    case PROCESSING = 102;
+    case EARLY_HINTS = 103;
+
+    /**
+     * 2xx (Successful): The request was successfully received, understood, and accepted.
+     */
+    case NO_CONTENT = 204;
+    case RESET_CONTENT = 205;
+
+    /**
+     * 3xx (Redirection): Further action needs to be taken in order to complete the request.
+     */
+    case NOT_MODIFIED = 304;
+
+    /**
+     * Check if a given status code should have no body.
+     */
+    public static function shouldHaveNoBody(int $statusCode): bool
+    {
+        return match ($statusCode) {
+            self::CONTINUE->value,
+            self::SWITCHING_PROTOCOLS->value,
+            self::PROCESSING->value,
+            self::EARLY_HINTS->value,
+            self::NO_CONTENT->value,
+            self::RESET_CONTENT->value,
+            self::NOT_MODIFIED->value => true,
+            default => false,
+        };
+    }
+}

--- a/tests/Http/Emitter/SapiEmitterTest.php
+++ b/tests/Http/Emitter/SapiEmitterTest.php
@@ -325,7 +325,7 @@ final class SapiEmitterTest extends \PHPUnit\Framework\TestCase
         $response = $this->createResponse(
             $code,
             ['Content-Type' => 'text/plain'],
-            'This content should not be emitted'
+            'This content should not be emitted',
         );
         $response = $response->withStatus($code, $phrase);
 
@@ -335,7 +335,7 @@ final class SapiEmitterTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['Content-Type: text/plain'], HTTPFunctions::headers_list());
         $this->assertSame(
             "HTTP/1.1 $code $phrase",
-            $this->httpResponseStatusLine($response)
+            $this->httpResponseStatusLine($response),
         );
         $this->expectOutputString('');
     }

--- a/tests/Provider/EmitterProvider.php
+++ b/tests/Provider/EmitterProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PHPPress\Tests\Provider;
 
+use PHPPress\Http\Emitter\HttpNoBodyStatus;
+
 /**
  * Provider for the {@see Emitter} class.
  *
@@ -30,6 +32,25 @@ final class EmitterProvider
             ['Contents', ['nte', 'nt'], 3, 2, 6],
             ['Contents', ['ts'], 2, 6, 8],
         ];
+    }
+
+    public static function noBodyStatusCodes(): array
+    {
+        return array_map(
+            fn(HttpNoBodyStatus $status): array => [
+                'code' => $status->value,
+                'phrase' => match($status) {
+                    HttpNoBodyStatus::CONTINUE => 'Continue',
+                    HttpNoBodyStatus::SWITCHING_PROTOCOLS => 'Switching Protocols',
+                    HttpNoBodyStatus::PROCESSING => 'Processing',
+                    HttpNoBodyStatus::EARLY_HINTS => 'Early Hints',
+                    HttpNoBodyStatus::NO_CONTENT => 'No Content',
+                    HttpNoBodyStatus::RESET_CONTENT => 'Reset Content',
+                    HttpNoBodyStatus::NOT_MODIFIED => 'Not Modified',
+                }
+            ],
+            HttpNoBodyStatus::cases()
+        );
     }
 
     public static function reasonPhrase(): array

--- a/tests/Provider/EmitterProvider.php
+++ b/tests/Provider/EmitterProvider.php
@@ -37,9 +37,9 @@ final class EmitterProvider
     public static function noBodyStatusCodes(): array
     {
         return array_map(
-            fn(HttpNoBodyStatus $status): array => [
+            static fn(HttpNoBodyStatus $status): array => [
                 'code' => $status->value,
-                'phrase' => match($status) {
+                'phrase' => match ($status) {
                     HttpNoBodyStatus::CONTINUE => 'Continue',
                     HttpNoBodyStatus::SWITCHING_PROTOCOLS => 'Switching Protocols',
                     HttpNoBodyStatus::PROCESSING => 'Processing',
@@ -47,9 +47,9 @@ final class EmitterProvider
                     HttpNoBodyStatus::NO_CONTENT => 'No Content',
                     HttpNoBodyStatus::RESET_CONTENT => 'Reset Content',
                     HttpNoBodyStatus::NOT_MODIFIED => 'Not Modified',
-                }
+                },
             ],
-            HttpNoBodyStatus::cases()
+            HttpNoBodyStatus::cases(),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
